### PR TITLE
ルート表示を改善

### DIFF
--- a/mitikusa/lib/components/map_state.dart
+++ b/mitikusa/lib/components/map_state.dart
@@ -236,11 +236,15 @@ class _MyMapState extends State<MyMap> {
 
     // ルートがちょうどよく収まるようにズーム
     final gmaps.LatLng southwest = gmaps.LatLng(
-        min(originLatLng.latitude, destinationLatLng.latitude),
-        min(originLatLng.longitude, destinationLatLng.longitude));
+        min(originLatLng.latitude,
+            min(intermediateLatLng.latitude, destinationLatLng.latitude)),
+        min(originLatLng.longitude,
+            min(intermediateLatLng.longitude, destinationLatLng.longitude)));
     final gmaps.LatLng northeast = gmaps.LatLng(
-        max(originLatLng.latitude, destinationLatLng.latitude),
-        max(originLatLng.longitude, destinationLatLng.longitude));
+        max(originLatLng.latitude,
+            max(intermediateLatLng.latitude, destinationLatLng.latitude)),
+        max(originLatLng.longitude,
+            max(intermediateLatLng.longitude, destinationLatLng.longitude)));
     const double padding = 100.0;
     _googleMapController.animateCamera(
       gmaps.CameraUpdate.newLatLngBounds(

--- a/mitikusa/lib/components/map_state.dart
+++ b/mitikusa/lib/components/map_state.dart
@@ -194,7 +194,7 @@ class _MyMapState extends State<MyMap> {
         ..add(gmaps.Polyline(
           polylineId: const gmaps.PolylineId('short'),
           visible: true,
-          color: Colors.black54,
+          color: Colors.blue,
           width: 5,
           points: pointsShort,
         ))


### PR DESCRIPTION
中継地が画面内に収まるようにした
最短ルートの表示色を黒から青に変更