### PR TITLE
[fix] キーボードを出したときにOVERFLOWEDエラーが出るバグを修正

### DIFF
--- a/mitikusa/lib/screens/input_page.dart
+++ b/mitikusa/lib/screens/input_page.dart
@@ -54,6 +54,7 @@ class MyInputPageState extends State<MyInputPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),


### PR DESCRIPTION
検索画面でキーボードを出したときにBOTTO OVERFLOWED BY 21 PIXELSがでてしまっていた部分を修正した．